### PR TITLE
Fix new parcel naming

### DIFF
--- a/src/HTMLExternalsAsset.js
+++ b/src/HTMLExternalsAsset.js
@@ -1,7 +1,7 @@
 const minimatch = require('minimatch');
 const HTMLAsset = parseInt(process.versions.node, 10) < 8
-  ? require('parcel-bundler/lib/assets/HTMLAsset')
-  : require('parcel-bundler/src/assets/HTMLAsset');
+  ? require('parcel/lib/assets/HTMLAsset')
+  : require('parcel/src/assets/HTMLAsset');
 
 class HTMLExternalsAsset extends HTMLAsset {
   async collectDependencies() {


### PR DESCRIPTION
Fix for #1.  Although it seems `parcel-bundler` is still pretty popular.  There may be a better way to accept both versions.